### PR TITLE
chore: fix node v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *~
 *.swp
 .DS_Store
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# We can't use lockfiles because npm@5 and npm@6 disagree about the syntax (and
-# will modify the lockfile when we run `npm install`).
-package-lock=false

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
-    "mocha": "^6.1.4",
+    "mocha": "^5.0.0",
     "shelljs": "^0.8.4",
     "shelljs-changelog": "^0.2.5",
     "shelljs-release": "^0.4.1",


### PR DESCRIPTION
This downgrades mocha to v5. Tested manually that eslint and mocha can
run now on node v4.