### PR TITLE
chore: fix eslint as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "sleepHelper.js"
   ],
   "devDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
-    "mocha": "^5.0.0",
+    "mocha": "^5.2.0",
     "shelljs": "^0.8.4",
     "shelljs-changelog": "^0.2.5",
     "shelljs-release": "^0.4.1",


### PR DESCRIPTION
Downgrade eslint because this also requires node >= v6.