### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,19 +29,19 @@
   ],
   "devDependencies": {
     "eslint": "^4.19.1",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.17.3",
+    "eslint-config-airbnb-base": "^13.2.0",
+    "eslint-plugin-import": "^2.26.0",
     "mocha": "^5.2.0",
     "shelljs": "^0.8.5",
     "shelljs-changelog": "^0.2.5",
-    "shelljs-release": "^0.5.1",
+    "shelljs-release": "^0.5.2",
     "should": "^13.2.3"
   },
   "peerDependencies": {
     "shelljs": "^0.8.5"
   },
   "optionalDependencies": {
-    "sleep": "^3.0.1"
+    "sleep": "^6.3.0"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
No change to logic. This only updates dependencies and adjusts code
style to conform to the new `eslint`.

The update was performed with:

```
nvm use v16 --delete-prefix
npm install -g npm-check-updates
"$(npm config get prefix)/bin/ncu" -u --enginesNode
```